### PR TITLE
Clean code after improvements in Scala.js 1.3.1

### DIFF
--- a/shared/src/main/scala/org/pfcoperez/thebutlerdidit/model/Report.scala
+++ b/shared/src/main/scala/org/pfcoperez/thebutlerdidit/model/Report.scala
@@ -5,15 +5,6 @@ import Report._
 
 case class Report(threads: Seq[ThreadDescription], deadLockElements: Set[DeadLockElement]) {
 
-  // Method replacing `x.formatted("%x")` which seems to be buggy in Scala.js
-  private def bigIntToHexStr(x: BigInt): String = {
-    val digitChar = (10 to 15).zip('a' to 'z').toMap
-    def digits(x: BigInt, acc: List[Int]): List[Int] =
-      if (x == 0) acc
-      else digits(x / 16, (x % 16).toInt :: acc)
-    "0x" + digits(x, Nil).map(d => s"${digitChar.getOrElse(d, d)}").mkString
-  }
-
   def asGraph: SparseGraph[ThreadId, ObjectReference] = {
 
     def threadId(thread: ThreadDescription): String = thread.name
@@ -28,9 +19,8 @@ case class Report(threads: Seq[ThreadDescription], deadLockElements: Set[DeadLoc
     threads.foldLeft(SparseGraph.empty[ThreadId, ObjectReference]) { case (graph, thread) =>
       val to = threadId(thread)
       thread.lockedBy.foldLeft(graph + to) { case (current, objAddr) =>
-        val hexStr = bigIntToHexStr(objAddr)
         objectToOwner.get(objAddr).map { from =>
-          current + (from -> hexStr -> to)
+          current + (from -> objAddr.formatted("%#x") -> to)
         } getOrElse (current)
 
       }


### PR DESCRIPTION
Remove custom BigInt hexadecimal string formatting code which was required due a Bug in Scala.js libraries fixed in Scala.js 1.3.1.

Previous to Scala.js 1.3.0, trying to use the method `BigInt#formatted` generated run-time exceptions, see https://github.com/scala-js/scala-js/issues/3407. https://github.com/scala-js/scala-js/pull/4255, included in https://github.com/scala-js/scala-js/releases/tag/v1.3.1 fixed this problem so the workaround code can be deleted.